### PR TITLE
loopForSensor(): Fix non-autoincrementing repeated reads

### DIFF
--- a/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
+++ b/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
@@ -1715,7 +1715,10 @@ loopForSensor(	const char *  tagString,
 	OSA_TimeDelay(100);
 
 	SEGGER_RTT_WriteString(0, tagString);
-	while ((address <= maxAddress) && autoIncrement)
+
+	// Keep on repeating until we are above the maxAddress, or just once if not autoIncrement-ing
+	// This is checked for at the tail end of the loop
+	while (true)
 	{
 		for (int i = 0; i < readCount; i++) for (int j = 0; j < chunkReadsPerAddress; j++)
 		{
@@ -1784,6 +1787,13 @@ loopForSensor(	const char *  tagString,
 		if (autoIncrement)
 		{
 			address++;
+		}
+
+		if (address > maxAddress || !autoIncrement)
+		{
+			// We either iterated over all possible addresses, or were asked to do only 
+			// one address anyway (i.e. don't increment), so we're done
+			break;
 		}
 	}
 

--- a/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
+++ b/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
@@ -1,5 +1,7 @@
 /*
 	Authored 2016-2018. Phillip Stanley-Marbell.
+	
+	Additional contributions, 2018: Jan Heck.
 
 	All rights reserved.
 
@@ -1716,8 +1718,10 @@ loopForSensor(	const char *  tagString,
 
 	SEGGER_RTT_WriteString(0, tagString);
 
-	// Keep on repeating until we are above the maxAddress, or just once if not autoIncrement-ing
-	// This is checked for at the tail end of the loop
+	/*
+	 *	Keep on repeating until we are above the maxAddress, or just once if not autoIncrement-ing
+	 *	This is checked for at the tail end of the loop.
+	 */
 	while (true)
 	{
 		for (int i = 0; i < readCount; i++) for (int j = 0; j < chunkReadsPerAddress; j++)
@@ -1791,8 +1795,10 @@ loopForSensor(	const char *  tagString,
 
 		if (address > maxAddress || !autoIncrement)
 		{
-			// We either iterated over all possible addresses, or were asked to do only 
-			// one address anyway (i.e. don't increment), so we're done
+			/*
+			 *	We either iterated over all possible addresses, or were asked to do only 
+			 *	one address anyway (i.e. don't increment), so we're done.
+			 */
 			break;
 		}
 	}


### PR DESCRIPTION
loopForSensor(): Change loop to check for its condition at the tail end, ensuring the loop is always performed at least once. This fixes repeated sensor reads (menu option 'j') never doing anything at all when doing non-auto-incrementing repeated reads of the same address. The previous version had

	while ((address <= maxAddress) && autoIncrement)

which would always be false if autoIncrement is false, therefore not doing anything in that case.