### PR TITLE
Update devAS7262.h to follow the coding convention (function names)

### DIFF
--- a/src/boot/ksdk1.1.0/devAS7262.h
+++ b/src/boot/ksdk1.1.0/devAS7262.h
@@ -47,5 +47,5 @@ WarpStatus	readSensorSignalAS7262(WarpTypeMask signal,
 					WarpSignalReliability reliability,
 					WarpSignalNoise noise);
 
-WarpStatus LEDonAS7262(void);
-WarpStatus LEDoffAS7262(void);
+WarpStatus LedOnAS7262(void);
+WarpStatus LedOffAS7262(void);


### PR DESCRIPTION
Aligns with `devAS7262.c` function names, to avoid implicit function declarations. Addresses issue #24 