### PR TITLE
Fixed bug in loopForSensor function

### DIFF
--- a/src/boot/ksdk1.1.0/devBME680.c
+++ b/src/boot/ksdk1.1.0/devBME680.c
@@ -170,7 +170,7 @@ configureSensorBME680(uint8_t payloadCtrl_Hum, uint8_t payloadCtrl_Meas, uint8_t
 	 *	Read the calibration registers
 	 */
 	for (	reg = kWarpSensorConfigurationRegisterBME680CalibrationRegion1Start;
-		reg <= kWarpSensorConfigurationRegisterBME680CalibrationRegion1End;
+		reg < kWarpSensorConfigurationRegisterBME680CalibrationRegion1End;
 		reg++)
 	{
 		status4 |= readSensorRegisterBME680(reg, 1 /* numberOfBytes */);
@@ -178,7 +178,7 @@ configureSensorBME680(uint8_t payloadCtrl_Hum, uint8_t payloadCtrl_Meas, uint8_t
 	}
 
 	for (	reg = kWarpSensorConfigurationRegisterBME680CalibrationRegion2Start;
-		reg <= kWarpSensorConfigurationRegisterBME680CalibrationRegion2End;
+		reg < kWarpSensorConfigurationRegisterBME680CalibrationRegion2End;
 		reg++)
 	{
 		status4 |= readSensorRegisterBME680(reg, 1 /* numberOfBytes */);

--- a/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
+++ b/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
@@ -2701,7 +2701,7 @@ loopForSensor(	const char *  tagString,
 {
 	WarpStatus		status; 
 	uint8_t			address;
-	if(minAddress < baseAddress <= maxAddress) 
+	if((minAddress < baseAddress) || (baseAddress <= maxAddress)) 
 	{ 
 		 address = baseAddress;
 	}

--- a/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
+++ b/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
@@ -2696,8 +2696,16 @@ loopForSensor(	const char *  tagString,
 		bool  chatty
 		)
 {
-	WarpStatus		status;
-	uint8_t			address = min(minAddress, baseAddress);
+	WarpStatus		status; 
+	uint8_t			address;
+	if(minAddress < baseAddress <= maxAddress) 
+	{ 
+		 address = baseAddress;
+	}
+	else 
+	{ 
+		address = minAddress;
+	}
 	int			readCount = repetitionsPerAddress + 1;
 	int			nSuccesses = 0;
 	int			nFailures = 0;


### PR DESCRIPTION
Previously the loop for sensor function would set: address = min(baseAddress, minAddress) this made it impossible the set the base address higher than the minAddress