### PR TITLE
Fixed HDC1000 reading issue

### DIFF
--- a/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
+++ b/src/boot/ksdk1.1.0/warp-kl03-ksdk1.1-boot.c
@@ -2547,7 +2547,7 @@ printAllSensors(bool printHeadersAndCalibration, bool hexModeFlag, int menuDelay
 
 	#ifdef WARP_BUILD_ENABLE_DEVHDC1000
 	numberOfConfigErrors += writeSensorRegisterHDC1000(kWarpSensorConfigurationRegisterHDC1000Configuration,/* Configuration register	*/
-					(0b1010000<<8),
+					(0b1000000<<8),
 					i2cPullupValue
 					);
 	#endif


### PR DESCRIPTION
HDC1000 reading error fix. Config Bit[12] set to 0 to enable independent temperature and humidity measurement.