### PR TITLE
Fix `caddr_t` compilation errors

### DIFF
--- a/tools/sdk/ksdk1.1.0/platform/utilities/src/fsl_misc_utilities.c
+++ b/tools/sdk/ksdk1.1.0/platform/utilities/src/fsl_misc_utilities.c
@@ -68,7 +68,7 @@ int _isatty (int fd)
 #endif
 
 #if (defined(__GNUC__) && (!defined(KDS)) && (!defined(ATOLLIC)))
-caddr_t
+void *
 _sbrk (int incr)
 {
   extern char   end asm ("end");
@@ -84,12 +84,12 @@ _sbrk (int incr)
   if (heap_end + incr > &heap_limit)
     {
       errno = ENOMEM;
-      return (caddr_t) -1;
+      return (void *) -1;
     }
 
   heap_end += incr;
 
-  return (caddr_t) prev_heap_end;
+  return (void *) prev_heap_end;
 }
 #endif
 

--- a/tools/sdk/ksdk1.1.0/platform/utilities/src/syscalls.c
+++ b/tools/sdk/ksdk1.1.0/platform/utilities/src/syscalls.c
@@ -77,7 +77,7 @@ int _write(int32_t file, uint8_t *ptr, int32_t len)
     return len;
 }
 
-caddr_t _sbrk(int32_t incr)
+void * _sbrk(int32_t incr)
 {
     extern uint8_t end asm("end");
     static uint8_t *heap_end;
@@ -93,12 +93,12 @@ caddr_t _sbrk(int32_t incr)
 //      write(1, "Heap and stack collision\n", 25);
 //      abort();
         errno = ENOMEM;
-        return (caddr_t) -1;
+        return (void *) -1;
     }
 
     heap_end += incr;
 
-    return (caddr_t) prev_heap_end;
+    return (void *) prev_heap_end;
 }
 
 int _close(int32_t file)


### PR DESCRIPTION
Two files in the Freescale SDK make use of `caddr_t` which is a presently unused data type. [This StackExchange discussion](https://stackoverflow.com/questions/6381526/what-is-the-significance-of-caddr-t-and-when-is-it-used) sheds more light into it and instructs all references of this type to be replaced with `void *`, which is what I have done in this PR. 

I'm not too sure why I got this error and some of my colleagues didn't, I can only assume it is because of my development platform: macOS Ventura with the latest ARM GNU toolchain downloaded 1 day ago: 12.2 rel-1. 

I'm not even sure if this is the right fix or if this breaks something, but I couldn't think of any alternatives. The function using this `_sbrk` itself confuses me as it is defined twice in two files with one conditionally existing on a couple of `#define`s that I don't have the time to look for. Might this be function overloading?

The firmware successfully compiled for me after this, so...